### PR TITLE
[BugFix] test_coverage and MKLThreads miniconda supported

### DIFF
--- a/RecModel/base_model.py
+++ b/RecModel/base_model.py
@@ -141,6 +141,9 @@ class RecModel:
 
         Returns:
             dict: return recall@N in dict format
+        TODO : efficiency improvement, need a efficient way to acess the sparse matrix
+        SparseEfficiencyWarning: Changing the sparsity structure of a csr_matrix is expensive. lil_matrix is more efficient.
+        self._set_arrayXarray(i, j, x)
         """
         assert rand_sampled_users is None or rand_sampled_users > 0, f'The number of test users ({rand_sampled_users}) should be > 0.'
         assert rand_sampled_items > 0, f'The number of random sampling items ({rand_sampled_items}) should be > 0.'

--- a/RecModel/base_model.py
+++ b/RecModel/base_model.py
@@ -12,6 +12,11 @@ def iter_rows_two_matrices(A, B):
     """
     Idea from FROM https://github.com/benanne/wmf/blob/master/wmf.py
     Getting the indices of each user for two matrices. Matrice A, B need the same number of rows!
+
+    Check the https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html
+    for csr_matrix meaning, 
+    csr_matrix.data means the nonzero elements in np.array format
+    csr_matrix.indices means the row index of nonzero elements in np.array format
     """
     # Make this save for empty rows!
 
@@ -61,13 +66,13 @@ class RecModel:
         pass
 
     def compute_hit(self, elem, rand_sampled, topn, dtype="float32"):
-        user, super_mat_dat, super_mat_idx, test_mat_dat, test_mat_idx = elem
-        if len(test_mat_dat) == 0:
+        user, super_mat_user_items, super_mat_user_items_idx, test_mat_user_items, test_mat_user_items_idx = elem
+        if len(test_mat_user_items) == 0:
             # Not a single item picked for this user in the test, mat
             return np.zeros(topn.shape, dtype=dtype)
         else:
             # Get all items the user bought in any of the matrices (i.e. the supermat)
-            items_selected = super_mat_idx
+            items_selected = super_mat_user_items_idx
 
             # Select a sample of rand_sampled items the user never bought.
 
@@ -96,7 +101,7 @@ class RecModel:
                 rand_items = np.append(rand_items, new_sample)"""
 
             sum_hits = np.zeros(topn.shape, dtype=dtype)
-            for item in test_mat_idx:
+            for item in test_mat_user_items_idx:
 
                 # Get the topn items form the random sampled items plus the truly bought item
                 rand_items[rand_pos] = item
@@ -125,7 +130,14 @@ class RecModel:
         :param topn: How many items should be looked for to find the potential hits?
         :param metric: Which metric should be used for evaluation? Should be one of  ARHR, PRECISION, RECALL
         :return: Evaluation score.
+
+        TODO
+            add param : n_users_in_test(int) default = None
+            modify param : rand_sampled(int) -> n_rand_sampled_items(int)
         """
+        # TODO
+        # assert n_users in test_mat
+        # sampling user in test_mat
         super_mat = test_mat
         if not train_mat is None:
             super_mat += train_mat
@@ -137,7 +149,8 @@ class RecModel:
         # if topn is not list make is one.
         if not isinstance(topn, np.ndarray):
             raise ValueError("Topn has to be a np.array")
-        # For each user, for each item select he interacted with, sample topn not selected items. Then let the model
+        # For each user, for each item select he interacted with,
+        # sample topn not selected items. Then let the model
         # rank the topn + 1 items at compare were the acutal by was ranked.
         hits = np.zeros(topn.shape, dtype=dtype)
         if cores == 1:

--- a/RecModel/base_model.py
+++ b/RecModel/base_model.py
@@ -190,7 +190,10 @@ class MKLThreads(object):
             try:
                 cls._mkl_rt = ctypes.CDLL('libmkl_rt.so')
             except OSError:
-                cls._mkl_rt = ctypes.CDLL('mkl_rt.dll')
+                try:
+                    cls._mkl_rt = ctypes.CDLL('mkl_rt.dll')
+                except OSError:
+                    cls._mkl_rt = ctypes.CDLL('libmkl_rt.dylib')  # for someone might use miniconda
         return cls._mkl_rt
 
     @classmethod

--- a/RecModel/recwalk_model.py
+++ b/RecModel/recwalk_model.py
@@ -4,13 +4,15 @@ import scipy.sparse
 import ctypes
 import os
 
-# Imports from own package. 
+# Imports from own package.
 from RecModel.base_model import RecModel
 from RecModel.fast_utils.slim_utils import _predict_slim, train_Slim
 
 # Helper functions
+
+
 def fill_empty_row_or_col(mat, fill_value=1.0):
-    mat=mat.copy()
+    mat = mat.copy()
 
     # First fill the empty rows
     empty_rows = (mat.sum(axis=1).A1 == 0)
@@ -22,23 +24,27 @@ def fill_empty_row_or_col(mat, fill_value=1.0):
     # If there are some columns remaining zero also fill them!
     empty_cols = (mat.sum(axis=0).A1 == 0)
     if empty_cols.any():
-        random_users=np.random.randint(0, mat.shape[0], empty_cols.sum())
+        random_users = np.random.randint(0, mat.shape[0], empty_cols.sum())
         mat[random_users, empty_cols] = fill_value
     return mat
+
 
 def create_A_g(mat):
     n_users, n_items = mat.shape
 
     # Built upper half.
-    zeros_upper_left = scipy.sparse.csr_matrix((n_users, n_users), dtype=np.float32) 
+    zeros_upper_left = scipy.sparse.csr_matrix(
+        (n_users, n_users), dtype=np.float32)
     upper_half = scipy.sparse.hstack([zeros_upper_left, mat], format='csr')
 
     # Build lower half.
-    zeros_lower_right = scipy.sparse.csr_matrix((n_items, n_items), dtype=np.float32)    
+    zeros_lower_right = scipy.sparse.csr_matrix(
+        (n_items, n_items), dtype=np.float32)
     lower_half = scipy.sparse.hstack([mat.T, zeros_lower_right], format='csr')
 
     A_g = scipy.sparse.vstack([upper_half, lower_half], format='csr')
     return A_g
+
 
 def create_H(mat):
     A_g = create_A_g(mat)
@@ -47,15 +53,18 @@ def create_H(mat):
     row_sums = A_g.sum(axis=1).A1
 
     # fill the digonal matrix with the inverse of row sums.
-    diag_inv_row_sum = scipy.sparse.diags(diagonals=(1 / row_sums), offsets=0, dtype=np.float32, format='csr')
+    diag_inv_row_sum = scipy.sparse.diags(diagonals=(
+        1 / row_sums), offsets=0, dtype=np.float32, format='csr')
 
     return diag_inv_row_sum.dot(A_g)
+
 
 def create_M_i(W_indptr, W_indices, W_data, n_items):
     """
     M_i is create by making W row stochastic. 
     """
-    W = scipy.sparse.csr_matrix((W_data, W_indices, W_indptr), shape=(n_items, n_items), dtype=np.float32)
+    W = scipy.sparse.csr_matrix((W_data, W_indices, W_indptr), shape=(
+        n_items, n_items), dtype=np.float32)
     W_normalized = W.copy()
 
     # Compute maximal row sums
@@ -66,20 +75,25 @@ def create_M_i(W_indptr, W_indices, W_data, n_items):
     W_normalized.data /= row_sum_max
 
     # Create diagonal mat that reintroduces the residuals to make the final Matrix row stochastic.
-    diag_mat = scipy.sparse.diags(diagonals = 1 - (row_sums / row_sum_max), offsets=0, dtype=np.float32, format='csr')
+    diag_mat = scipy.sparse.diags(
+        diagonals=1 - (row_sums / row_sum_max), offsets=0, dtype=np.float32, format='csr')
 
     M_i = W_normalized + diag_mat
 
     return M_i
+
 
 def create_M(indptr, indices, data, n_users, n_items):
     # Make W row stochastic.
     M_i = create_M_i(indptr, indices, data, n_items)
 
     # Fill the rest of the matrix with zeros and the upper left with an identity matrix.
-    I = scipy.sparse.diags(diagonals=np.full(n_users, 1, dtype=np.float32), offsets=0, dtype=np.float32, format='csr')
-    zeros_upper_right = scipy.sparse.csr_matrix((n_users, n_items), dtype=np.float32)    
-    zeros_lower_left = scipy.sparse.csr_matrix((n_items, n_users), dtype=np.float32)    
+    I = scipy.sparse.diags(diagonals=np.full(
+        n_users, 1, dtype=np.float32), offsets=0, dtype=np.float32, format='csr')
+    zeros_upper_right = scipy.sparse.csr_matrix(
+        (n_users, n_items), dtype=np.float32)
+    zeros_lower_left = scipy.sparse.csr_matrix(
+        (n_items, n_users), dtype=np.float32)
 
     upper_half = scipy.sparse.hstack([I, zeros_upper_right], format='csr')
     lower_half = scipy.sparse.hstack([zeros_lower_left, M_i], format='csr')
@@ -88,13 +102,16 @@ def create_M(indptr, indices, data, n_users, n_items):
     return M
 
 # Recwalk model
+
+
 class Recwalk(RecModel):
     def __init__(self, num_items, num_users, k_steps, eval_method, damping=None, slim_W=None):
-        
-        if not eval_method in ['k_step', 'PR']:
-            raise ValueError(f"eval method needs to be one of ['k_step', 'PR], not {eval_method}")
 
-        self.num_users = num_users       
+        if not eval_method in ['k_step', 'PR']:
+            raise ValueError(
+                f"eval method needs to be one of ['k_step', 'PR], not {eval_method}")
+
+        self.num_users = num_users
         self.num_items = num_items
         self.k = k_steps
         self.eval_method = eval_method
@@ -102,7 +119,8 @@ class Recwalk(RecModel):
 
         if eval_method == 'PR':
             if damping is None:
-                raise ValueError("If you want to use the power method to rank the items (eval_method = 'PR') please provide the damping factor.")
+                raise ValueError(
+                    "If you want to use the power method to rank the items (eval_method = 'PR') please provide the damping factor.")
             self.damping = damping
 
         if not slim_W is None:
@@ -111,10 +129,10 @@ class Recwalk(RecModel):
         else:
             self.slim_trained = False
 
-    def rank(self, items, users, topn):     
+    def rank(self, items, users, topn):
         # Create the representation of the user:
         user_vec = np.zeros(self.num_items + self.num_users, dtype=np.float32)
-        user_vec[users] = 1.0  
+        user_vec[users] = 1.0
 
         # Choose the prediction method.
         if self.eval_method == 'k_step':
@@ -123,23 +141,26 @@ class Recwalk(RecModel):
             for _ in range(self.k):
                 user_vec = scipy.sparse.csr_matrix.dot(self.P, user_vec)
             predictions = user_vec[items + self.num_users]
-            
+
         else:
             # Prediction based on the stationary distribution with restarts.
             # make hard copy of user_vec as user_vec is used throughout the computation.
             vec_out = user_vec.copy()
             for _ in range(self.k):
-                vec_out = self.damping * scipy.sparse.csr_matrix.dot(self.P, vec_out) + (1-self.damping) * user_vec
+                vec_out = self.damping * \
+                    scipy.sparse.csr_matrix.dot(
+                        self.P, vec_out) + (1 - self.damping) * user_vec
                 vec_out = vec_out / (np.linalg.norm(vec_out) + 1e-10)
             predictions = vec_out[items + self.num_users]
 
         # Extract the relevant predictions from the computed vector (take the relevant item nodes)
-        
+
         # Finally sort the prediction and return the relevant items.
         return items[np.argpartition(predictions, list(range(-topn, 0, 1)))[-topn:]][::-1]
 
     def predict(self, users, items):
-        raise NotImplementedError("Predict is not defined for the RecWalk method.") 
+        raise NotImplementedError(
+            "Predict is not defined for the RecWalk method.")
 
     def train(self, train_mat, phi, alpha, l1_ratio, max_iter, tolerance, cores, verbose):
         """
@@ -161,12 +182,14 @@ class Recwalk(RecModel):
 
         # Train underlying slim model.
         if self.slim_trained is False:
-            # Train slim 
-            indptr, indices, data = train_Slim(X=train_mat_csc, alpha=alpha, l1_ratio=l1_ratio, max_iter=max_iter, tol=tolerance, cores=cores, verbose=verbose)
+            # Train slim
+            indptr, indices, data = train_Slim(
+                X=train_mat_csc, alpha=alpha, l1_ratio=l1_ratio, max_iter=max_iter, tol=tolerance, cores=cores, verbose=verbose)
         else:
             # Use pre-trained slim weights
-            indptr, indices, data = (self.slim_W.indptr, self.slim_W.indices, self.slim_W.data)
-        
+            indptr, indices, data = (
+                self.slim_W.indptr, self.slim_W.indices, self.slim_W.data)
+
         # Fill the empty rows / columsn of the train mat with an entry of 1.0 at a random position to ensure stochasticity of the matrix.
         train_mat = fill_empty_row_or_col(train_mat)
 
@@ -191,7 +214,8 @@ class Recwalk(RecModel):
         if self.P is not None:
             np.save(dir, self.P)
         else:
-            raise ValueError("There is no computed P matrix because the model was not trained yet. Please train it with Recwalker.train().")
+            raise ValueError(
+                "There is no computed P matrix because the model was not trained yet. Please train it with Recwalker.train().")
 
     def load_P(self, dir='P.npy'):
         try:

--- a/RecModel/slim_model.py
+++ b/RecModel/slim_model.py
@@ -5,17 +5,20 @@ import scipy.sparse
 import ctypes
 import os
 
-# Imports from own package. 
+# Imports from own package.
 from RecModel.base_model import RecModel
 from RecModel.fast_utils.slim_utils import _predict_slim, train_Slim
+
 
 class Slim(RecModel):
     def __init__(self, num_items, num_users):
         self.num_users = num_users
         self.num_items = num_items
 
-    def rank(self, items, users, topn):           
-        predictions = self.predict(np.full(len(items), users, dtype=np.int32), items.astype(np.int32))
+    def rank(self, items, users, topn):
+        predictions = self.predict(
+            np.full(len(items), users, dtype=np.int32),
+            items.astype(np.int32))
         return items[np.argpartition(predictions, list(range(-topn, 0, 1)))[-topn:]][::-1]
 
     def train(self, X, alpha, l1_ratio, max_iter, tolerance, cores, verbose):
@@ -26,10 +29,11 @@ class Slim(RecModel):
 
         X_train = X.tocsc()
         X_train.sort_indices()
-        
-        self.W_indptr, self.W_idx, self.W_data = train_Slim(X=X_train, alpha=alpha, l1_ratio=l1_ratio, max_iter=max_iter, tol=tolerance, cores=cores, verbose=verbose)
-        
-        # To predit a csr matrix is needed.        
+
+        self.W_indptr, self.W_idx, self.W_data = train_Slim(
+            X=X_train, alpha=alpha, l1_ratio=l1_ratio, max_iter=max_iter, tol=tolerance, cores=cores, verbose=verbose)
+
+        # To predit a csr matrix is needed.
         X_eval = X.tocsr()
         X_eval.sort_indices()
         self.A_indptr = X_eval.indptr
@@ -38,14 +42,16 @@ class Slim(RecModel):
 
     def predict(self, users, items):
 
-        # Either items of length 1 and users of different length, 
+        # Either items of length 1 and users of different length,
         if (users.shape[0] != items.shape[0]):
-            raise ValueError(f"Users and items need to have the same shape, but users.shape[0]={users.shape[0]} and items.shape[0]={items.shape[0]} is not possible!")
+            raise ValueError(
+                f"Users and items need to have the same shape, but users.shape[0]={users.shape[0]} and items.shape[0]={items.shape[0]} is not possible!")
 
         # Allocate output array
         pred = np.empty(items.shape[0], dtype=np.float64)
-        _predict_slim(users, items, pred, self.A_indptr, self.W_indptr, self.A_idx, self.W_idx, self.A_data, self.W_data)
-        
+        _predict_slim(users, items, pred, self.A_indptr, self.W_indptr,
+                      self.A_idx, self.W_idx, self.A_data, self.W_data)
+
         return pred
 
     @property
@@ -54,4 +60,4 @@ class Slim(RecModel):
         idx = np.array(self.W_idx).copy()
         data = np.array(self.W_data).copy()
 
-        return scipy.sparse.csc_matrix((data, idx, indptr), dtype=np.float64, shape = (self.num_items, self.num_items))
+        return scipy.sparse.csc_matrix((data, idx, indptr), dtype=np.float64, shape=(self.num_items, self.num_items))

--- a/RecModel/utils.py
+++ b/RecModel/utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def test_coverage(cls, Train, topN):
+def test_coverage(cls, Train, topN, rand_sampled_users=1000, random_state=None):
     """
         Testing the coverage of the algorithm:
         It is assumed cls is a object of classes derived 
@@ -14,10 +14,20 @@ def test_coverage(cls, Train, topN):
         :param cls : RecModel
         :param Train : scipy.sparse.csr_matrix, shape (Users, Items)
         :param topN : int, top N items to be select by recommender
+        :rand_sampled_users : int, random sampled user for efficient evaluation, defaults to 1000
+        :param random_state : int, seed for rand_sampled_users defaults to None
     """
+    assert rand_sampled_users is None or rand_sampled_users > 0, f'The number of test users ({rand_sampled_users}) should be > 0.'
+    if rand_sampled_users is None:
+        rand_sampled_users = Train.shape[0]
+    else:
+        rand_sampled_users = Train.shape[0] if rand_sampled_users is None else min(
+            rand_sampled_users, Train.shape[0])
+    print(f'This process will sampling {rand_sampled_users}')
+    rand_user_ids = np.random.choice(
+        np.arange(Train.shape[0]), size=rand_sampled_users, replace=False)
     item_counts = np.zeros(Train.shape[1], dtype=np.int32)
-
-    for user in range(Train.shape[0]):
+    for user in rand_user_ids:
         start_usr = Train.indptr[user]
         end_usr = Train.indptr[user + 1]
 

--- a/RecModel/utils.py
+++ b/RecModel/utils.py
@@ -1,20 +1,34 @@
 import numpy as np
 
+
 def test_coverage(cls, Train, topN):
-    """Testing the coverage of the algorithm:
-        It is assumed cls is a object of classes derived from RecModel and is able to rank items with a rank function.
     """
-    item_counts = np.zeros(Train.shape[0], dtype=np.int32)
+        Testing the coverage of the algorithm:
+        It is assumed cls is a object of classes derived 
+        from RecModel and is able to rank items with 
+        a rank function.
+
+        `idxptr` : row index of sparse matrix
+        https://stackoverflow.com/questions/52299420/scipy-csr-matrix-understand-indptr
+
+        :param cls : RecModel
+        :param Train : scipy.sparse.csr_matrix, shape (Users, Items)
+        :param topN : int, top N items to be select by recommender
+    """
+    item_counts = np.zeros(Train.shape[1], dtype=np.int32)
 
     for user in range(Train.shape[0]):
         start_usr = Train.indptr[user]
-        end_usr = Train.indptr[user+1]
+        end_usr = Train.indptr[user + 1]
 
-        items_to_rank = np.delete(np.arange(Train.shape[1], dtype=np.int32), Train.indices[start_usr:end_usr])
-        ranked_items = cls.rank(users=user, items=items_to_rank, topn=topN).reshape(-1)
+        items_to_rank = np.delete(
+            np.arange(Train.shape[1], dtype=np.int32), Train.indices[start_usr:end_usr])
+        ranked_items = cls.rank(
+            users=user, items=items_to_rank, topn=topN).reshape(-1)
         item_counts[ranked_items[:topN]] += 1
-    
+
     return item_counts
+
 
 def train_test_split_sparse_mat(matrix, train=0.8, seed=1993):
     np.random.seed(seed)
@@ -31,5 +45,5 @@ def train_test_split_sparse_mat(matrix, train=0.8, seed=1993):
 
     train_data.eliminate_zeros()
     test_data.eliminate_zeros()
-    
+
     return [train_data, test_data]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+
+from setuptools import setup
+setup(
+    name='RecModel',  # Required
+    description='RecModel',  # Optional
+)


### PR DESCRIPTION
Hi @titoeb

Thanks for your great repo so that I can study RecWalk(2019) in Python.

Currently I found out there is only one python-based RecWalk implementation on github.

It's your repo! I'm glad that I have a chance to contribute.

I fix 1 bug and add miniconda support of MKLThreads.

# 1. test_coverage bug:

`utils.py` line 7

`item_counts = np.zeros(Train.shape[0], dtype=np.int32)` should be `Train.shape[1]`

Train.shape : (users, items). 

I validate it by `example.ipynb`.  The `RecModel.NaiveBaseline` should give us coverage = 1.0 (which makes sense).

# 2. MKLThreads miniconda supported.

I don't have `libmkl_rt.so` for `ctypes.CDLL` function in `base_model.py` line 191 and 193.

After checked [this](https://gitter.im/eaton-lab/Lobby?at=59cedbd6cfeed2eb65694337)

It turned out I installed miniconda instead of anaconda. miniconda use `libmkl_rt.dylib` which is slower. 

But we can prevent miniconda user from the error.

